### PR TITLE
Install passwd by default

### DIFF
--- a/alma/helpers/build.sh
+++ b/alma/helpers/build.sh
@@ -19,7 +19,8 @@ dnf install -y --allowerasing \
     less \
     man-db \
     bind-utils \
-    net-tools
+    net-tools \
+    passwd
 
 
 # disable services we do not need


### PR DESCRIPTION
passwd command is missing in the default build and this breaks custom image builds at the cleanup_root() function https://github.com/TritonDataCenter/sdc-imgapi/blob/master/tools/prepare-image/linux-prepare-image#L107

This throws `errexit 127` (command not found) at the image creation step and never succeeds.

Works with this change.