### PR TITLE
Fix Void Linux Image Generation

### DIFF
--- a/void/Dockerfile
+++ b/void/Dockerfile
@@ -1,3 +1,3 @@
-FROM voidlinux/voidlinux
+FROM ghcr.io/void-linux/void-glibc-full
 COPY helpers /helpers
 RUN cd /helpers; sh build.sh; cd /; rm -rf helpers

--- a/void/helpers/build.sh
+++ b/void/helpers/build.sh
@@ -30,7 +30,8 @@ xbps-install -ySu \
 	ncurses-base \
 	openssh joe vim \
 	rsyslog \
-	jq
+	jq \
+	bash
 
 xbps-alternatives -g vi -s vim-common
 


### PR DESCRIPTION
Void Linux no longer uses docker hub for their container images, so it was switched to their official ghcr image. I also add `bash` as a package because otherwise the machine would fail to provision since bash would be missing.

Overall, the system works well now.